### PR TITLE
Add Tailwind styling and Japanese docs

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env", "@babel/preset-react"]
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# texteditor-copilot
+# TextEditor Copilot
+
+このプロジェクトは、シンプルなテキストエディタと AI 補完パネルを組み合わせた React アプリです。スタイルには Tailwind CSS を使用しています。
+
+## 使い方
+
+1. 依存パッケージをインストール
+   ```bash
+   npm install
+   ```
+2. 開発サーバーを起動
+   ```bash
+   npm start
+   ```
+
+ブラウザが自動的に開きます。テキストエディタにコードを書き、右側のパネルに Copilot の提案を表示できます。

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "texteditor-copilot",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.21",
+    "postcss-loader": "^7.0.1",
+    "tailwindcss": "^3.3.5"
+  },
+  "scripts": {
+    "start": "webpack serve --mode development --open",
+    "build": "webpack --mode production"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TextEditor Copilot</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/src/App.js
+++ b/src/App.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import TextEditor from './components/TextEditor';
+import Copilot from './components/Copilot';
+
+function App() {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <header className="bg-gray-800 text-white p-4">
+        <h1 className="text-xl">TextEditor Copilot</h1>
+      </header>
+      <div className="flex flex-1">
+        <TextEditor />
+        <Copilot />
+      </div>
+    </div>
+  );
+}
+
+export default App;

--- a/src/components/Copilot.js
+++ b/src/components/Copilot.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function Copilot() {
+  return (
+    <div className="w-1/3 p-4 overflow-y-auto">
+      <div className="font-bold mb-2">Copilot</div>
+      <p>Here you could display AI suggestions or code completions.</p>
+    </div>
+  );
+}
+
+export default Copilot;

--- a/src/components/TextEditor.js
+++ b/src/components/TextEditor.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+function TextEditor() {
+  return (
+    <div className="flex-1 p-4 border-r border-gray-300">
+      <textarea
+        className="w-full h-full p-2 border rounded"
+        placeholder="Write your code here..."
+      />
+    </div>
+  );
+}
+
+export default TextEditor;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./src/**/*.{js,jsx}', './public/index.html'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,36 @@
+const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+  entry: './src/index.js',
+  output: {
+    path: path.resolve(__dirname, 'build'),
+    filename: 'bundle.js',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-env', '@babel/preset-react'],
+          },
+        },
+      },
+      {
+        test: /\.css$/,
+        use: ['style-loader', 'css-loader', 'postcss-loader'],
+      },
+    ],
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: './public/index.html',
+    }),
+  ],
+  devServer: {
+    static: './build',
+  },
+};


### PR DESCRIPTION
## Summary
- integrate Tailwind CSS via PostCSS and config files
- update React components to use Tailwind classes
- document usage in Japanese

## Testing
- `npm test --silent` *(fails: no test script defined)*

------
https://chatgpt.com/codex/tasks/task_e_683d0bbd5a4c83289cac34f0e111ff55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a React-based text editor application with an AI-powered Copilot suggestion panel.
  - Added a user interface featuring a header, a code editor, and a side panel for AI suggestions.

- **Documentation**
  - Rewrote the README with a comprehensive Japanese introduction and step-by-step usage instructions.

- **Chores**
  - Added configuration files for Babel, PostCSS, Tailwind CSS, and Webpack to support modern JavaScript, React, and utility-first styling.
  - Established project metadata, dependencies, and scripts for development and production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->