### PR TITLE
Add basic React text editor with Copilot panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# texteditor-copilot
+# Text Editor Copilot
+
+This is a minimal example of a text editor with a Copilot-like suggestion panel using **React**, **Vite**, **TypeScript**, and **Tailwind CSS**.
+
+To start development after installing dependencies:
+
+```bash
+npm install
+npm run dev
+```
+
+The editor is a simple `<textarea>` and the copilot panel displays static suggestions. You can extend it by connecting to your own backend for dynamic completions.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Text Editor Copilot</title>
+  </head>
+  <body class="h-screen">
+    <div id="root" class="h-full"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "texteditor-copilot",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "tailwindcss": "^3.3.0",
+    "typescript": "^5.0.0",
+    "vite": "^4.0.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,21 @@
+import Editor from './components/Editor';
+import CopilotPanel from './components/CopilotPanel';
+import { useState } from 'react';
+
+function App() {
+  const [suggestions] = useState([
+    { id: 1, text: 'Example suggestion 1' },
+    { id: 2, text: 'Example suggestion 2' },
+  ]);
+
+  return (
+    <div className="relative h-full flex">
+      <div className="flex-1">
+        <Editor />
+      </div>
+      <CopilotPanel suggestions={suggestions} />
+    </div>
+  );
+}
+
+export default App;

--- a/src/components/CopilotPanel.tsx
+++ b/src/components/CopilotPanel.tsx
@@ -1,0 +1,19 @@
+export type Suggestion = { id: number; text: string };
+
+const CopilotPanel = ({ suggestions }: { suggestions: Suggestion[] }) => {
+  return (
+    <div className="w-64 border-l border-gray-200 p-2 overflow-y-auto">
+      <h2 className="font-bold mb-2">Suggestions</h2>
+      {suggestions.map((s) => (
+        <div
+          key={s.id}
+          className="mb-1 p-1 cursor-pointer hover:bg-gray-100 rounded"
+        >
+          {s.text}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default CopilotPanel;

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -1,0 +1,10 @@
+const Editor = () => {
+  return (
+    <textarea
+      className="w-full h-full p-2 border border-gray-300 rounded"
+      placeholder="Start typing..."
+    />
+  );
+};
+
+export default Editor;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{"path": "./tsconfig.node.json"}]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- initialize React + Vite project
- add Tailwind config and styling
- implement simple textarea editor and suggestion panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683d1265b354832898a5dee076d0bd60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a minimal text editor with a Copilot-like suggestion panel, featuring a simple textarea and a static suggestions panel.
- **Documentation**
  - Expanded and clarified the README with project overview and setup instructions.
- **Chores**
  - Added initial project setup files, including configuration for React, TypeScript, Tailwind CSS, Vite, and related tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->